### PR TITLE
chore: add license and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# Poetry
+.poetry/
+*.lock
+dist/
+build/
+*.egg-info/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Jupyter
+.ipynb_checkpoints
+.profile_default/
+.ipython/
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# VS Code
+.vscode/
+
+# Logs and temporary files
+*.log
+*.tmp
+*.swp
+*.swo
+*.bak
+*.old
+
+# pyenv and Python-specific files
+.python-version
+pip-wheel-metadata/
+*.manifest
+
+# Testing
+htmlcov/
+.coverage
+.cache
+.nox/
+tox/
+.pytest_cache/
+
+# OSQP generated files (if C extensions used)
+osqp_sources/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 James Parkington
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell   
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN  
+THE SOFTWARE.


### PR DESCRIPTION
### 🔥 Quick Summary
This PR adds the initial `.gitignore` and `LICENSE` files to the Thermur repository, which help enforce good development hygiene and clarify the permissive licensing model for future collaboration and reuse.

***

### 🐦‍⬛ Key Changes
- **`.gitignore`**: Adds standard patterns for macOS, Python (Poetry), Jupyter, and editor/IDE artifacts. Helps ensure the repo stays clean and reproducible across environments.
- **`LICENSE`**: Applies the MIT License to the project, granting broad rights to use, modify, and distribute the code.